### PR TITLE
fix: ComplexType imports were generating with a '\n' in the end

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,13 +1,13 @@
 package main
 
 import (
-	"fmt"
-	"os"
-	"strings"
-	"io/ioutil"
-	"regexp"
-	"go/build"
 	"errors"
+	"fmt"
+	"go/build"
+	"io/ioutil"
+	"os"
+	"regexp"
+	"strings"
 )
 
 type config struct {
@@ -134,7 +134,7 @@ func generateGodashCodeForType(imp string, importLocation string) error {
 			return err
 		}
 		if tpl == "_ComplexType" {
-			err := searchAndReplaceInFile(file, "_ImportLocation", importLocation)
+			err := searchAndReplaceInFile(file, "_ImportLocation", importLocation[:len(importLocation)-1])
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Hi, PR for #2 
Generating go-dash for complex types, the imports in generated go-dash code has a '\n' (a newline character).

Earlier: 
```
import . "github.com/go-dash/slice/tests/types
" 
```
which pop-ups error.

Now:
``` import . "github.com/go-dash/slice/tests/types" ```

Fixed.